### PR TITLE
Fixes to the guide

### DIFF
--- a/build.mkd
+++ b/build.mkd
@@ -17,10 +17,22 @@ Ubuntu and/or have a Linux system running.
 We will be using a [Vagrant][] managed VirtualBox install as a base system.
 
 1. Download and install Vagrant from a [pre-built package][vagrantdl]
-2. From the command line, set up an Ubuntu Precise instance with:
+2. From the command line, download an Ubuntu Precise box with:
 
         vagrant box add precise32 http://files.vagrantup.com/precise32.box
+
+3.- Create an instance of Ubuntu Precise with:
+
+        mkdir validator
+        cd validator
         vagrant init
+
+4. Edit the generated Vagrantfile and tell Vagrant to use the precise32 box:
+
+        config.vm.box = "precise32"
+
+5. Launch the server instance:
+
         vagrant up
 
 Your Ubuntu virtual machine should now be up and running. Confirm by running:
@@ -106,7 +118,7 @@ When prompted, type:
 
 3. Test the Validator's command line tool:
 
-        /usr/local/validator/cgi-bin/check uri=http://www.w3.org
+        /usr/local/validator/httpd/cgi-bin/check uri=http://www.w3.org
 
 If some HTML output is printed to screen, Validator is installed and ready to
 go.
@@ -159,7 +171,7 @@ Here, we'll be using Apache but the same principles apply to any web server.
 
 2. Copy Validator's HTTP server configuration:
 
-        sudo cp ~/build/validator-1.3/httpd/conf/httpd.conf /etc/w3c/
+        sudo cp /usr/local/validator/httpd/conf/httpd.conf /etc/w3c/
         sudo ln -s /etc/w3c/httpd.conf /etc/apache2/conf.d/w3c-validator.conf
         sudo ln -s /usr/local/validator/htdocs/ /var/www/w3c-validator
 


### PR DESCRIPTION
Hey Tom, great work!

It's almost working. I've been able to install everything and run the validator from the command line. I made some minor fixes to the guide.

I haven't been able to run it through the web server, though. When I go to http://localhost:8080 I see it there, but without styles (css, layout...), and if I try to validate an URL, it says:

```
Not Found

The requested URL /w3c-validator/check was not found on this server.

Apache/2.2.22 (Ubuntu) Server at localhost Port 8080
```

I think there must be some misconfiguration about the paths or something.

Also, we need a way to have all services running automatically on server restart (that is, no need to launch the validator.nu manually). How can this be done?
