### PR TITLE
Fix line about confirming startup of validator-nu

### DIFF
--- a/readme.mkd
+++ b/readme.mkd
@@ -189,7 +189,7 @@ Validator.
 
 After rebooting, Validator.nu should be running. Confirm by running:
 
-    pgrep -fl java | grep validator
+    sudo ps aux | grep validator-nu
 
 ### Set up a web server
 


### PR DESCRIPTION
Hey Tom, the guide works perfectly, I've tested it from the start on an Ubuntu Precise 64 bits server.

I just needed to change this line about confirming the validator-nu was running (nothing was being output with the "pgrep..." line)
