### PR TITLE
Update guide

### DIFF
--- a/readme.mkd
+++ b/readme.mkd
@@ -63,7 +63,7 @@ port forwarding:
         cd ~
         mkdir build
         cd build
-        wget http://github.com/downloads/petdance/tidyp/tidyp-1.04.tar.gz
+        wget https://cloud.github.com/downloads/petdance/tidyp/tidyp-1.04.tar.gz
         tar -xzf tidyp-1.04.tar.gz
         cd tidyp-1.04
         ./configure
@@ -134,7 +134,7 @@ Validator.
 
 1. Install Validator.nu's build dependencies:
 
-        sudo apt-get install git mercurial subversion default-jdk
+        sudo apt-get install git default-jdk
 
 2. Build Validator.nu:
 


### PR DESCRIPTION
Validator.nu has now been moved to Github, this updates the guide to reflect the latest installation instructions.
